### PR TITLE
Implements sia codes CL,OP, solves ZO bug for wireless PIR.

### DIFF
--- a/pyspcwebgw/zone.py
+++ b/pyspcwebgw/zone.py
@@ -1,7 +1,7 @@
 import logging
 
-from pyspcwebgw.const import ZoneInput, ZoneType, ZoneStatus
-from pyspcwebgw.utils import _load_enum
+from .const import ZoneInput, ZoneType, ZoneStatus
+from .utils import _load_enum
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -49,7 +49,12 @@ class Zone:
 
     def update(self, spc_zone, sia_code=None):
         _LOGGER.debug("Update zone %s", self.id)
-
-        self._input = _load_enum(ZoneInput, spc_zone['input'])
+        
         self._type = _load_enum(ZoneType, spc_zone['type'])
         self._status = _load_enum(ZoneStatus, spc_zone['status'])
+        
+        """Sanity check and override too short opening time if necessary"""
+        if sia_code == 'ZO' and spc_zone['input'] == '0':
+            self._input = _load_enum(ZoneInput, '1')
+        else:
+            self._input = _load_enum(ZoneInput, spc_zone['input'])


### PR DESCRIPTION
Made imports within the class relative to easier be used as custom_component.
Added SIA codes CL, OP that is sent instead of CG, OG if only one area is used in SPC.
Set last_changed_by='N/A' for area partset, beacuse the last partset user is not provided by SPC.
Force Zone open if sia_code = ZO, to solve problem with some wireless zones reporting open for 0 duration that led to no status change registration.