### PR TITLE
Expose ethernet information

### DIFF
--- a/examples/example1.py
+++ b/examples/example1.py
@@ -29,6 +29,7 @@ async def init(loop):
     print(
         f"Connected to SPC {spc.info['variant']}, serial no "
         f"{spc.info['sn']} running firmware {spc.info['version']}."
+        f"available at {spc.ethernet['ip_address']}"
     )
 
     # Connect the websocket

--- a/pyspcwebgw/__init__.py
+++ b/pyspcwebgw/__init__.py
@@ -24,6 +24,7 @@ class SpcWebGateway:
         self._info = None
         self._areas = {}
         self._zones = {}
+        self._ethernet = {}
         self._websocket = None
         self._async_callback = async_callback
 
@@ -41,6 +42,11 @@ class SpcWebGateway:
     def zones(self):
         """Retrieve all available zones."""
         return self._zones
+
+    @property
+    def ethernet(self):
+        """Retrieve all ethernet information."""
+        return self._ethernet
 
     def start(self):
         """Connect websocket to SPC Web Gateway."""
@@ -60,6 +66,8 @@ class SpcWebGateway:
     async def async_load_parameters(self):
         """Fetch area and zone info from SPC to initialize."""
         self._info = await self._async_get_data("panel")
+        self._ethernet = await self._async_get_data("ethernet")
+
         zones = await self._async_get_data("zone")
         areas = await self._async_get_data("area")
 


### PR DESCRIPTION
I would like ethernet information exposed so that we can have a "visit" button on home assistant. I have some work at https://github.com/home-assistant/core/pull/87915 to move it over to configflow and assign unique ids to the entities.

![spc](https://user-images.githubusercontent.com/1243435/218881265-0f1e75e7-ab3d-4012-8911-fad18be91897.gif)
